### PR TITLE
[tlib][net] fix the memory leaks

### DIFF
--- a/tlib/src/net.cpp
+++ b/tlib/src/net.cpp
@@ -21,10 +21,10 @@ tlib::packet& tlib::packet::operator=(packet&& rhs) {
         this->fd      = rhs.fd;
         this->payload = rhs.payload;
         this->index   = rhs.index;
-
+        
         rhs.payload = nullptr;
     }
-
+    
     return *this;
 }
 
@@ -40,7 +40,7 @@ std::expected<size_t> tlib::socket_open(socket_domain domain, socket_type type, 
                  : [fd] "=m"(fd)
                  : [domain] "g"(static_cast<size_t>(domain)), [type] "g"(static_cast<size_t>(type)), [protocol] "g"(static_cast<size_t>(protocol))
                  : "rax", "rbx", "rcx", "rdx");
-
+    
     if (fd < 0) {
         return std::make_expected_from_error<size_t, size_t>(-fd);
     } else {
@@ -57,14 +57,14 @@ void tlib::socket_close(size_t fd) {
 
 std::expected<tlib::packet> tlib::prepare_packet(size_t socket_fd, void* desc) {
     auto buffer = malloc(2048);
-
+    
     int64_t fd;
     uint64_t index;
     asm volatile("mov rax, 0x3002; mov rbx, %[socket]; mov rcx, %[desc]; mov rdx, %[buffer]; int 50; mov %[fd], rax; mov %[index], rbx;"
                  : [fd] "=m"(fd), [index] "=m"(index)
                  : [socket] "g"(socket_fd), [desc] "g"(reinterpret_cast<size_t>(desc)), [buffer] "g"(reinterpret_cast<size_t>(buffer))
                  : "rax", "rbx", "rcx", "rdx");
-
+    
     if (fd < 0) {
         free(buffer);
         return std::make_expected_from_error<tlib::packet, size_t>(-fd);
@@ -79,13 +79,13 @@ std::expected<tlib::packet> tlib::prepare_packet(size_t socket_fd, void* desc) {
 
 std::expected<void> tlib::finalize_packet(size_t socket_fd, const tlib::packet& p) {
     auto packet_fd = p.fd;
-
+    
     int64_t code;
     asm volatile("mov rax, 0x3003; mov rbx, %[socket]; mov rcx, %[packet]; int 50; mov %[code], rax"
                  : [code] "=m"(code)
                  : [socket] "g"(socket_fd), [packet] "g"(packet_fd)
                  : "rax", "rbx", "rcx");
-
+    
     if (code < 0) {
         return std::make_expected_from_error<void, size_t>(-code);
     } else {
@@ -99,7 +99,7 @@ std::expected<void> tlib::listen(size_t socket_fd, bool l) {
                  : [code] "=m"(code)
                  : [socket] "g"(socket_fd), [listen] "g"(size_t(l))
                  : "rax", "rbx", "rcx");
-
+    
     if (code < 0) {
         return std::make_expected_from_error<void, size_t>(-code);
     } else {
@@ -113,7 +113,7 @@ std::expected<size_t> tlib::client_bind(size_t socket_fd) {
                  : [code] "=m"(code)
                  : [socket] "g"(socket_fd)
                  : "rax", "rbx", "rcx");
-
+    
     if (code < 0) {
         return std::make_unexpected<size_t, size_t>(-code);
     } else {
@@ -127,7 +127,7 @@ std::expected<size_t> tlib::connect(size_t socket_fd, tlib::ip::address server, 
                  : [code] "=m"(code)
                  : [socket] "g" (socket_fd), [ip] "g" (size_t(server.raw_address)), [port] "g" (port)
                  : "rax", "rbx", "rcx", "rdx");
-
+    
     if (code < 0) {
         return std::make_unexpected<size_t, size_t>(-code);
     } else {
@@ -141,7 +141,7 @@ std::expected<void> tlib::disconnect(size_t socket_fd) {
                  : [code] "=m"(code)
                  : [socket] "g" (socket_fd)
                  : "rax", "rbx");
-
+    
     if (code < 0) {
         return std::make_unexpected<void, size_t>(-code);
     } else {
@@ -151,16 +151,16 @@ std::expected<void> tlib::disconnect(size_t socket_fd) {
 
 std::expected<tlib::packet> tlib::wait_for_packet(size_t socket_fd) {
     auto buffer = malloc(2048);
-
+    
     int64_t code;
     uint64_t payload;
     asm volatile("mov rax, 0x3005; mov rbx, %[socket]; mov rcx, %[buffer]; int 50; mov %[code], rax; mov %[payload], rbx;"
                  : [payload] "=m"(payload), [code] "=m"(code)
                  : [socket] "g"(socket_fd), [buffer] "g"(reinterpret_cast<size_t>(buffer))
                  : "rax", "rbx", "rcx");
-
-    free(buffer);
+    
     if (code < 0) {
+        free(buffer);
         return std::make_expected_from_error<packet, size_t>(-code);
     } else {
         tlib::packet p;
@@ -172,16 +172,16 @@ std::expected<tlib::packet> tlib::wait_for_packet(size_t socket_fd) {
 
 std::expected<tlib::packet> tlib::wait_for_packet(size_t socket_fd, size_t ms) {
     auto buffer = malloc(2048);
-
+    
     int64_t code;
     uint64_t payload;
     asm volatile("mov rax, 0x3006; mov rbx, %[socket]; mov rcx, %[buffer]; mov rdx, %[ms]; int 50; mov %[code], rax; mov %[payload], rbx;"
                  : [payload] "=m"(payload), [code] "=m"(code)
                  : [socket] "g"(socket_fd), [buffer] "g"(reinterpret_cast<size_t>(buffer)), [ms] "g"(ms)
                  : "rax", "rbx", "rcx");
-
-    free(buffer);
+    
     if (code < 0) {
+        free(buffer);
         return std::make_expected_from_error<packet, size_t>(-code);
     } else {
         tlib::packet p;
@@ -192,15 +192,15 @@ std::expected<tlib::packet> tlib::wait_for_packet(size_t socket_fd, size_t ms) {
 }
 
 tlib::socket::socket(socket_domain domain, socket_type type, socket_protocol protocol)
-        : domain(domain), type(type), protocol(protocol), fd(0), error_code(0) {
+: domain(domain), type(type), protocol(protocol), fd(0), error_code(0) {
     auto open_status = tlib::socket_open(domain, type, protocol);
-
+    
     if (open_status.valid()) {
         fd = *open_status;
     } else {
         error_code = open_status.error();
     }
-
+    
     local_port = 0;
 }
 
@@ -208,7 +208,7 @@ tlib::socket::~socket() {
     if(connected()){
         disconnect();
     }
-
+    
     if (fd) {
         tlib::socket_close(fd);
     }
@@ -242,7 +242,7 @@ void tlib::socket::listen(bool l) {
     if (!good() || !open()) {
         return;
     }
-
+    
     auto status = tlib::listen(fd, l);
     if (!status) {
         error_code = status.error();
@@ -253,12 +253,12 @@ void tlib::socket::client_bind() {
     if (!good() || !open()) {
         return;
     }
-
+    
     auto status = tlib::client_bind(fd);
     if (!status) {
         error_code = status.error();
     }
-
+    
     local_port = *status;
 }
 
@@ -266,7 +266,7 @@ void tlib::socket::connect(tlib::ip::address server, size_t port) {
     if (!good() || !open()) {
         return;
     }
-
+    
     auto status = tlib::connect(fd, server, port);
     if (status) {
         _connected = true;
@@ -280,13 +280,13 @@ void tlib::socket::disconnect() {
     if (!good() || !open()) {
         return;
     }
-
+    
     if(!connected()){
         return;
     }
-
+    
     auto status = tlib::disconnect(fd);
-
+    
     if(status){
         _connected = false;
     } else {
@@ -298,9 +298,9 @@ tlib::packet tlib::socket::prepare_packet(void* desc) {
     if (!good() || !open()) {
         return tlib::packet();
     }
-
+    
     auto packet = tlib::prepare_packet(fd, desc);
-
+    
     if (!packet) {
         error_code = packet.error();
         return tlib::packet();
@@ -313,7 +313,7 @@ void tlib::socket::finalize_packet(const tlib::packet& p) {
     if (!good() || !open()) {
         return;
     }
-
+    
     auto status = tlib::finalize_packet(fd, p);
     if (!status) {
         error_code = status.error();
@@ -324,9 +324,9 @@ tlib::packet tlib::socket::wait_for_packet() {
     if (!good() || !open()) {
         return tlib::packet();
     }
-
+    
     auto p = tlib::wait_for_packet(fd);
-
+    
     if (!p) {
         error_code = p.error();
         return tlib::packet();
@@ -339,9 +339,9 @@ tlib::packet tlib::socket::wait_for_packet(size_t ms) {
     if (!good() || !open()) {
         return tlib::packet();
     }
-
+    
     auto p = tlib::wait_for_packet(fd, ms);
-
+    
     if (!p) {
         error_code = p.error();
         return tlib::packet();

--- a/tlib/src/net.cpp
+++ b/tlib/src/net.cpp
@@ -66,6 +66,7 @@ std::expected<tlib::packet> tlib::prepare_packet(size_t socket_fd, void* desc) {
                  : "rax", "rbx", "rcx", "rdx");
 
     if (fd < 0) {
+        free(buffer);
         return std::make_expected_from_error<tlib::packet, size_t>(-fd);
     } else {
         tlib::packet p;
@@ -158,8 +159,8 @@ std::expected<tlib::packet> tlib::wait_for_packet(size_t socket_fd) {
                  : [socket] "g"(socket_fd), [buffer] "g"(reinterpret_cast<size_t>(buffer))
                  : "rax", "rbx", "rcx");
 
+    free(buffer);
     if (code < 0) {
-        free(buffer);
         return std::make_expected_from_error<packet, size_t>(-code);
     } else {
         tlib::packet p;
@@ -179,8 +180,8 @@ std::expected<tlib::packet> tlib::wait_for_packet(size_t socket_fd, size_t ms) {
                  : [socket] "g"(socket_fd), [buffer] "g"(reinterpret_cast<size_t>(buffer)), [ms] "g"(ms)
                  : "rax", "rbx", "rcx");
 
+    free(buffer);
     if (code < 0) {
-        free(buffer);
         return std::make_expected_from_error<packet, size_t>(-code);
     } else {
         tlib::packet p;


### PR DESCRIPTION
Greetings @wichtounet,

On line numbers `69`, `168`, & `189` of [net.cpp](https://github.com/bryongloden/thor-os/blob/develop/tlib/src/net.cpp#L69) there are memory leaks, which are bugs.

The reason we should `free` is that memory is a finite resource within our running programs. Sure in very short running simple programs, failing to `free` memory won't have a noticeable effect. However on long running programs, failing to `free` memory means we will be consuming a finite resource without replenishing it. Eventually it will run out and our program will abruptly crash. This is why we must `free` memory.
