### PR TITLE
Added no-relax flag for programs linker

### DIFF
--- a/cpp.mk
+++ b/cpp.mk
@@ -40,7 +40,7 @@ TLIB_FLAGS=$(COMMON_CPP_FLAGS) $(FLAGS_64) $(WARNING_FLAGS) -mcmodel=small -fPIC
 TLIB_LINK_FLAGS=$(COMMON_CPP_FLAGS) $(FLAGS_64) $(WARNING_FLAGS) -mcmodel=small -fPIC -Wl,-gc-sections
 
 PROGRAM_FLAGS=$(COMMON_CPP_FLAGS) $(FLAGS_64) $(WARNING_FLAGS) -I../../tlib/include/ -I../../printf/include/  -static -L../../tlib/debug/ -ltlib -mcmodel=small -fPIC -DTHOR_PROGRAM=yes
-PROGRAM_LINK_FLAGS=$(COMMON_CPP_FLAGS) $(FLAGS_64) $(WARNING_FLAGS) $(COMMON_LINK_FLAGS) -static -L../../tlib/debug/ -mcmodel=small -fPIC -z max-page-size=0x1000 -T ../linker.ld
+PROGRAM_LINK_FLAGS=$(COMMON_CPP_FLAGS) $(FLAGS_64) $(WARNING_FLAGS) $(COMMON_LINK_FLAGS) -static -L../../tlib/debug/ -mcmodel=small -fPIC -z max-page-size=0x1000 -T ../linker.ld -Xlinker "--no-relax"
 
 NO_COLOR=\x1b[0m
 MODE_COLOR=\x1b[31;01m


### PR DESCRIPTION
Removed linker addressing optimization for avoid "failed to convert GOTPCREL relocation" error