### PR TITLE
Add optional parameter to syscall reboot/shutdown

### DIFF
--- a/tlib/src/system.cpp
+++ b/tlib/src/system.cpp
@@ -100,7 +100,9 @@ std::expected<size_t> tlib::exec_and_wait(const char* executable, const std::vec
 }
 
 void tlib::reboot(int delay=0) {
-    tlib::sleep_ms(1000*delay);
+    if (delay != 0) {
+    tlib::sleep_ms(1000 * delay);
+    }
     asm volatile("mov rax, 0x50; int 50"
         : //No outputs
         : //No inputs
@@ -110,7 +112,9 @@ void tlib::reboot(int delay=0) {
 }
 
 void tlib::shutdown(int delay=0){
-    tlib::sleep_ms(1000* delay);
+    if (delay != 0) {
+    tlib::sleep_ms(1000 * delay);
+    }
     asm volatile("mov rax, 0x51; int 50"
         : //No outputs
         : //No inputs

--- a/tlib/src/system.cpp
+++ b/tlib/src/system.cpp
@@ -99,7 +99,8 @@ std::expected<size_t> tlib::exec_and_wait(const char* executable, const std::vec
     return std::move(result);
 }
 
-void tlib::reboot(){
+void tlib::reboot(int delay=0) {
+    tlib::sleep_ms(1000*delay);
     asm volatile("mov rax, 0x50; int 50"
         : //No outputs
         : //No inputs
@@ -108,7 +109,8 @@ void tlib::reboot(){
     __builtin_unreachable();
 }
 
-void tlib::shutdown(){
+void tlib::shutdown(int delay=0){
+    tlib::sleep_ms(1000* delay);
     asm volatile("mov rax, 0x51; int 50"
         : //No outputs
         : //No inputs


### PR DESCRIPTION
Added a optional parameter to tlib::shutdown and tlib::reboot that waits the number of seconds, to enable timed shutdowns/reboots