### PR TITLE
Updated the members of GDT-descriptor structure

### DIFF
--- a/kernel/include/gdt_types.hpp
+++ b/kernel/include/gdt_types.hpp
@@ -50,18 +50,18 @@ struct gdt_ptr {
 } __attribute__ ((packed));
 
 struct gdt_descriptor_t {
-    unsigned int limit_low      : 16;
-    unsigned int base_low       : 24;
+    uint16_t limit_low           : 16;
+    uint32_t base_low           : 24;
     uint8_t type                : 4;
-    unsigned int always_1       : 1;
-    unsigned int dpl            : 2;
-    unsigned int present        : 1;
-    unsigned int limit_high     : 4;
-    unsigned int avl            : 1;
-    unsigned int long_mode      : 1;
-    unsigned int big            : 1;
-    unsigned int granularity    : 1;
-    unsigned int base_high      : 8;
+    uint8_t always_1            : 1;
+    uint8_t dpl                 : 2;
+    uint8_t present             : 1;
+    uint8_t limit_high          : 4;
+    uint8_t avl                 : 1;
+    uint8_t long_mode           : 1;
+    uint8_t big                 : 1;
+    uint8_t granularity         : 1;
+    uing32_t base_high          : 8;
 } __attribute__((packed));
 
 static_assert(sizeof(gdt_descriptor_t) == 8, "GDT selector in long mode is 8 bytes long");


### PR DESCRIPTION
I've updated the types for the members of the GDT-descriptor structure (gdt_descriptor_t) to not all be 32-bit integers.