### PR TITLE
Removed qword functions

### DIFF
--- a/kernel/include/kernel_utils.hpp
+++ b/kernel/include/kernel_utils.hpp
@@ -56,23 +56,7 @@ inline uint32_t in_dword(uint16_t _port){
     return rv;
 }
 
-inline uint64_t in_qword(uint16_t _port){
-    uint64_t rv;
-
-    asm volatile ("in %[data], %[port]"
-        : [data] "=a" (rv)
-        : [port] "dN" (_port));
-
-    return rv;
-}
-
 inline void out_dword(uint16_t _port, uint32_t _data){
-    asm volatile ("out %[port], %[data]"
-        :  /* No outputs */
-        : [port] "dN" (_port), [data] "a" (_data));
-}
-
-inline void out_qword(uint16_t _port, uint64_t _data){
     asm volatile ("out %[port], %[data]"
         :  /* No outputs */
         : [port] "dN" (_port), [data] "a" (_data));


### PR DESCRIPTION
I've removed port input and output functions for qwords, as you can only out a dword max to a port.