### PR TITLE
Some minor tweaks for building on Ubuntu Focal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,19 +30,20 @@ thor.flp: hdd.img bootloader/stage1.bin bootloader/stage2.bin init/debug/init.bi
 	mkdir -p mnt/fake/
 	dd if=bootloader/stage1.bin of=hdd.img conv=notrunc
 	dd if=bootloader/stage2.bin of=hdd.img seek=1 conv=notrunc
-	sudo /sbin/losetup -o1048576 /dev/loop0 hdd.img
-	sudo mkdosfs -v -F32 /dev/loop0
-	sudo /bin/mount -t vfat /dev/loop0 mnt/fake/
-	sudo mkdir mnt/fake/bin/
-	sudo mkdir mnt/fake/sys/
-	sudo mkdir mnt/fake/dev/
-	sudo mkdir mnt/fake/proc/
-	sudo /bin/cp init/debug/init.bin mnt/fake/
-	sudo /bin/cp kernel/debug/kernel.bin mnt/fake/
-	sudo /bin/cp programs/dist/* mnt/fake/bin/
-	sleep 0.1
-	sudo /bin/umount mnt/fake/
-	sudo /sbin/losetup -d /dev/loop0
+	loopdev="`/sbin/losetup -f`" && \
+	sudo /sbin/losetup -o1048576 "$$loopdev" hdd.img && \
+	sudo mkdosfs -v -F32 "$$loopdev" && \
+	sudo /bin/mount -t vfat "$$loopdev" mnt/fake/ && \
+	sudo mkdir mnt/fake/bin/ && \
+	sudo mkdir mnt/fake/sys/ && \
+	sudo mkdir mnt/fake/dev/ && \
+	sudo mkdir mnt/fake/proc/ && \
+	sudo /bin/cp init/debug/init.bin mnt/fake/ && \
+	sudo /bin/cp kernel/debug/kernel.bin mnt/fake/ && \
+	sudo /bin/cp programs/dist/* mnt/fake/bin/ && \
+	sleep 0.1 && \
+	sudo /bin/umount mnt/fake/ && \
+	sudo /sbin/losetup -d "$$loopdev"
 
 qemu: default
 	touch virtual.log

--- a/cpp.mk
+++ b/cpp.mk
@@ -51,7 +51,7 @@ define compile_assembly_folder
 
 debug/$(1)/%.s.o: $(1)/%.s
 	@ mkdir -p debug/$(1)/
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (assembly) $(FILE_COLOR)$(1)/$$*.s$(NO_COLOR)"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (assembly) $(FILE_COLOR)$(1)/$$*.s$(NO_COLOR)"
 	@ $(AS) -g -c $$< -o $$@
 
 folder_s_files := $(wildcard $(1)/*.s)
@@ -70,7 +70,7 @@ debug/$(1)/%.cpp.d: $(1)/%.cpp
 
 debug/$(1)/%.cpp.o: $(1)/%.cpp
 	@ mkdir -p debug/$(1)/
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
 	@ $(CXX) $(KERNEL_CPP_FLAGS_64) $(THOR_FLAGS) $(WARNING_FLAGS) -c $$< -o $$@
 
 folder_cpp_files := $(wildcard $(1)/*.cpp)
@@ -91,7 +91,7 @@ debug/acpica/source/components/$(1)/%.c.d: acpica/source/components/$(1)/%.c
 
 debug/acpica/source/components/$(1)/%.c.o: acpica/source/components/$(1)/%.c
 	@ mkdir -p debug/acpica/source/components/$(1)/
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (ACPICA) $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (ACPICA) $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
 	@ $(CC) $(ACPICA_C_FLAGS) $(THOR_FLAGS) -c $$< -o $$@
 
 acpica_folder_c_files := $(wildcard acpica/source/components/$(1)/*.c)
@@ -108,7 +108,7 @@ define program_compile_cpp_folder
 
 debug/$(1)/%.cpp.o: $(1)/%.cpp
 	@ mkdir -p debug/$(1)/
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (program) $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (program) $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
 	@ $(CXX) -c $$< -o $$@ $(PROGRAM_FLAGS)
 
 folder_cpp_files := $(wildcard $(1)/*.cpp)
@@ -122,7 +122,7 @@ define program_link_executable
 
 debug/$(1): $(O_FILES)
 	@ mkdir -p debug/
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Link (program) $(FILE_COLOR)$$@$(NO_COLOR)"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Link (program) $(FILE_COLOR)$$@$(NO_COLOR)"
 	@ $(CXX) -o debug/$(1) $(PROGRAM_LINK_FLAGS) ../../tlib/debug/src/crti.s.o $$(shell $(CXX) -print-file-name=crtbegin.o) $(O_FILES) -ltlib $$(shell $(CXX) -print-file-name=crtend.o) ../../tlib/debug/src/crtn.s.o
 link: debug/$(1)
 
@@ -137,7 +137,7 @@ debug/$(1)/%.cpp.d: $(1)/%.cpp
 
 debug/$(1)/%.cpp.o: $(1)/%.cpp
 	@ mkdir -p debug/$(1)/
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (tlib) $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Compile (tlib) $(FILE_COLOR)$(1)/$$*.cpp$(NO_COLOR)"
 	@ $(CXX) $(TLIB_FLAGS) -c $$< -o $$@
 
 folder_cpp_files := $(wildcard $(1)/*.cpp)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -14,13 +14,13 @@ force_look:
 	true
 
 dist: tlib/libtlib.a
-	@ echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Build all programs"
+	@ /bin/echo -e "$(MODE_COLOR)[debug]$(NO_COLOR) Build all programs"
 	@ $(foreach var,$(PROGRAMS),cd $(var); $(MAKE); cd ..;)
 	@ mkdir -p dist
 	@ $(foreach var,$(PROGRAMS),cp $(var)/debug/$(var) dist/;)
 	@ strip dist/*
 
 clean:
-	@ echo -e "Clean all programs"
+	@ /bin/echo -e "Clean all programs"
 	@ $(foreach var,$(PROGRAMS),cd $(var); $(MAKE) clean; cd ..;)
 	@ rm -rf dist


### PR DESCRIPTION
The proposed patches do the following:

  * Use `/bin/echo` rather than the shell's builtin `echo` to provide colourised output when building the project.  (On Ubuntu 20.04.2, `/bin/sh` is `dash`, whose builtin `echo` command does not understand the `-e` option.)
  * Rather than assume that the loopback device file `/dev/loop0` is available, use `/sbin/losetup -f` to find a loopback device file which is actually available.

Thank you!